### PR TITLE
Fix example code for `lazy`

### DIFF
--- a/src/Random.elm
+++ b/src/Random.elm
@@ -597,8 +597,8 @@ random number of probabilities:
     probabilities =
       Random.andThen identity <|
         Random.uniform
-          [ Random.constant []
-          , Random.map2 (::)
+          (Random.constant [])
+          [ Random.map2 (::)
               (Random.float 0 1)
               (Random.lazy (\_ -> probabilities))
           ]


### PR DESCRIPTION
The example code for `lazy` doesn't compile, because it gives a `List` as the only argument to `uniform` (rather than a non-empty list -- that is, an item and a list).

So, this PR just fixes the example code.